### PR TITLE
Fix attributes quote

### DIFF
--- a/src/LaravelBBCode.php
+++ b/src/LaravelBBCode.php
@@ -29,9 +29,6 @@ class LaravelBBCode {
      */
     public static function decode($content='')
     {
-        // First make sure, the content is HTML entities encoded.
-        $content = e($content);
-
         // Instantiate the Decoda-object.
         // We use null as the configPath to keep Decoda from using
         // it's built in (emoticon- and censorship-configs),


### PR DESCRIPTION
Hello,

HTML entities are already encoded by default with Decoda (escapeHtml). https://github.com/milesj/decoda/blob/master/src/Decoda/Decoda.php#L91

When attribute have a space, you must put double-quotes. So double-quotes should not be convert in HTML.

Example :
`[quote="name first name"]lorem[/quote]`